### PR TITLE
Fix undefined variable notice on reload

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -29,6 +29,7 @@ function fax_getdestinfo($dest) {
 
 function fax_check_destinations($dest=true) {
 	global $active_modules;
+	global $version;
 
 	$ast_lt_18 = version_compare($version, '1.8', 'lt');
 	$fax=fax_detect();


### PR DESCRIPTION
Someone forgot to make a variable global.
